### PR TITLE
Ensure notify-send is available

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.qubes-os.org
 
 Package: qubes-tunnel
 Architecture: all
-Depends: ${misc:Depends}, qubes-core-agent-networking, iptables, openvpn
+Depends: ${misc:Depends}, qubes-core-agent-networking, iptables, openvpn, libnotify-bin
 Description: Qubes service for simple, secure VPN tunnels.
  Qubes service for ProxyVMs as secure VPN tunnel gateways. Combines anti-leak
  firewall, DNS and systemd service that accepts config files from your

--- a/rpm_spec/qubes-tunnel.spec.in
+++ b/rpm_spec/qubes-tunnel.spec.in
@@ -13,6 +13,7 @@ BuildRequires:	make
 Requires:	iptables
 Requires:	openvpn
 Requires:	qubes-core-agent-networking
+Requires:	libnotify
 
 %description
 Qubes service for ProxyVMs as secure VPN tunnel gateways. Combines anti-leak


### PR DESCRIPTION
We also need to get rid of that. This is also the purpose of having
https://github.com/QubesOS/qubes-issues/issues/889.

See https://forum.qubes-os.org/t/cant-get-the-qubesos-contrib-qubes-tunnel-to-work-in-4-1/8550/8?u=fepitre