### PR TITLE
updated requirements to play well with fedora-36-minimal

### DIFF
--- a/rpm_spec/qubes-tunnel.spec.in
+++ b/rpm_spec/qubes-tunnel.spec.in
@@ -14,6 +14,9 @@ Requires:	iptables
 Requires:	openvpn
 Requires:	qubes-core-agent-networking
 Requires:	libnotify
+Requires:	sssd-client
+Requires:	dbus-x11
+Requires:	notification-daemon
 
 %description
 Qubes service for ProxyVMs as secure VPN tunnel gateways. Combines anti-leak


### PR DESCRIPTION
`ssshd-client`, `dbus-x11` and `notification-daemon` were missing from the list of requirements. Please double check the changes, I have now idea how the spec.in file works or how to test it.

Additionally, this package isn't listed for fedora-37 for some reason.

P.S.: `notification-daemon` behaves differently in fedora-36-minimal and fedora-36 where fedora-36-minimal adds a notification-tray icon. Maybe there is better fitting package?